### PR TITLE
Get All User Data

### DIFF
--- a/src/user/api-objects/api-user.js
+++ b/src/user/api-objects/api-user.js
@@ -42,26 +42,13 @@ class ApiUser extends ApiObject {
           subResources.map(resource =>
             this._getResourceIDsFromApi(userID, resource.resolver)
           ))
-          .then(IDs => {
-            return {
-              loans: IDs[0],
-              requests: IDs[1],
-              fees: IDs[2]
-            }
-          })
+          .then(IDs => formatUserResources(userID, IDs))
       })
       .then(user => Promise.all(
         subResources.map(resource =>
           this._resolveResources(userID, user[resource.name], resource.resolver)
         )))
-      .then(data => {
-        return {
-          primary_id: userID,
-          loans: data[0],
-          requests: data[1],
-          fees: data[2]
-        }
-      })
+      .then(data => formatUserResources(userID, data))
   }
 
   getLoans (userID) {
@@ -113,6 +100,15 @@ const formatCacheUser = user => {
     loans: user.loan_ids,
     requests: user.request_ids,
     fees: user.fee_ids
+  }
+}
+
+const formatUserResources = (userID, responses) => {
+  return {
+    primary_id: userID,
+    loans: responses[0],
+    requests: responses[1],
+    fees: responses[2]
   }
 }
 

--- a/test/user-test/api-objects-test/user-test.js
+++ b/test/user-test/api-objects-test/user-test.js
@@ -41,11 +41,17 @@ describe('api user class tests', () => {
 
   describe('get method tests', () => {
     it('should call getFromCache with the provided ID', () => {
-      const getFromCacheStub = stubMethod('getFromCache')
-      wire('formatCacheUser')
+      const testUserID = uuid()
+
+      const getFromCacheStub = stubMethod('getFromCache', true, {
+        primary_id: testUserID,
+        loan_ids: [],
+        request_ids: [],
+        fee_ids: []
+      })
+      // wire('formatCacheUser')
 
       const testApiUser = new ApiUser()
-      const testUserID = uuid()
 
       return testApiUser.get(testUserID)
         .then(() => {
@@ -53,9 +59,9 @@ describe('api user class tests', () => {
         })
     })
 
-    it('should call getFromApi with the ID if getFromCache rejects', () => {
+    it('should call _getResourceIDsFromApi with the ID if getFromCache rejects', () => {
       stubMethod('getFromCache', false)
-      const getFromApiStub = stubMethod('getFromApi')
+      const getFromApiStub = stubMethod('_getResourceIDsFromApi', true, [])
       const testApiUser = new ApiUser()
       sandbox.stub(testApiUser.queue, 'sendMessage').resolves()
 
@@ -64,6 +70,7 @@ describe('api user class tests', () => {
       return testApiUser.get(testUserID)
         .then(() => {
           getFromApiStub.should.have.been.calledWith(testUserID)
+          getFromApiStub.should.have.been.calledThrice
         })
     })
   })


### PR DESCRIPTION
This changes the `GET /users/<userID>` endpoint to return complete user data, consisting of complete arrays of all of the user's `loans`, `requests` and `fees`.