### PR TITLE
Dynamic ARN Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4685,6 +4685,12 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "serverless-pseudo-parameters": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.1.0.tgz",
+      "integrity": "sha512-RnsvKBAjqp0gm/WWKizsxsHtok9JHZ+U7/JvRCFrst68z7b6Ktu8EDI89CyFQYjU2b4w1zSiiCYI95UbZMIIxA==",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nock": "^9.4.2",
     "nyc": "^11.6.0",
     "rewire": "^4.0.1",
+    "serverless-pseudo-parameters": "^2.1.0",
     "sinon": "^5.0.2",
     "sinon-chai": "^3.0.0",
     "uuid": "^3.3.2"

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
       Action:
         - ssm:GetParameter
       Resource:
-        - ${env:ALMA_API_KEY_ARN}
+        - ${self:custom.prefixes.SSM}${env:ALMA_API_KEY_NAME}
 
 functions:
   userHandler:
@@ -158,15 +158,15 @@ custom:
 
   TableArns:
     stg:
-      usersTable: ${env:USER_TABLE_ARN_STG}
-      loansTable: ${env:LOAN_TABLE_ARN_STG}
-      requestsTable: ${env:REQUEST_TABLE_ARN_STG}
-      feesTable: ${env:FEE_TABLE_ARN_STG}
+      usersTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.stg.usersTable}
+      loansTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.stg.loansTable}
+      requestsTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.stg.requestsTable}
+      feesTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.stg.feesTable}
     prod:
-      usersTable: ${env:USER_TABLE_ARN_PROD}
-      loansTable: ${env:LOAN_TABLE_ARN_PROD}
-      requestsTable: ${env:REQUEST_TABLE_ARN_PROD}
-      feesTable: ${env:FEE_TABLE_ARN_PROD}
+      usersTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.prod.usersTable}
+      loansTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.prod.loansTable}
+      requestsTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.prod.requestsTable}
+      feesTable: ${self:custom.prefixes.DynamoDB}/${self:custom.TableNames.prod.feesTable}
   
   QueueUrls:
     stg:
@@ -191,3 +191,10 @@ custom:
       loansQueue: ${env:LOAN_QUEUE_ARN_PROD}
       requestsQueue: ${env:REQUEST_QUEUE_ARN_PROD}
       feesQueue: ${env:FEE_QUEUE_ARN_PROD}
+  
+  Prefixes:
+    DynamoDB: arn:aws:dynamodb:${opt:region}:#{AWS::AccountId}:table
+    SSM: arn:aws:ssm:${opt:region}:#{AWS::AccountId}:parameter
+
+plugins:
+   - serverless-pseudo-parameters


### PR DESCRIPTION
This changes `serverless.yml` to generate DynamoDB Table and SSM Parameter ARNs dynamically from the AWS region, account ID, and resource name environment variables.

This reduces the number of configuration environment variables that need to be provided for deployment. 